### PR TITLE
Add support for notifying rooms

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,11 +28,13 @@ type ConfigsModel struct {
 	fromName string
 	message  string
 	color    string
+	notify   string
 
 	//onFail
 	fromNameOnError string
 	messageOnError  string
 	colorOnError    string
+	notifyOnError   string
 
 	//settings
 	messageFormat     string
@@ -51,10 +53,12 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		fromName: os.Getenv("from_name"),
 		message:  os.Getenv("message"),
 		color:    os.Getenv("color"),
+		notify:   os.Getenv("notify"),
 
 		fromNameOnError: os.Getenv("from_name_on_error"),
 		messageOnError:  os.Getenv("message_on_error"),
 		colorOnError:    os.Getenv("color_on_error"),
+		notifyOnError:   os.Getenv("notify_on_error"),
 
 		messageFormat:     os.Getenv("message_format"),
 		isBuildFailedMode: os.Getenv("BITRISE_BUILD_STATUS"),
@@ -70,10 +74,12 @@ func (configs ConfigsModel) print() {
 	log.Printf("- fromName: %s", configs.fromName)
 	log.Printf("- message: %s", configs.message)
 	log.Printf("- color: %s", configs.color)
+	log.Printf("- notify: %s", configs.notify)
 
 	log.Printf("- fromNameOnError: %s", configs.fromNameOnError)
 	log.Printf("- messageOnError: %s", configs.messageOnError)
 	log.Printf("- colorOnError: %s", configs.colorOnError)
+	log.Printf("- notifyOnError: %s", configs.notifyOnError)
 
 	log.Printf("- messageFormat: %s", configs.messageFormat)
 }
@@ -96,6 +102,7 @@ func main() {
 		config.fromName = config.fromNameOnError
 		config.message = config.messageOnError
 		config.color = config.colorOnError
+		config.notify = config.notifyOnError
 	}
 
 	//
@@ -110,6 +117,7 @@ func main() {
 		"message":        {config.message},
 		"color":          {config.color},
 		"message_format": {config.messageFormat},
+		"notify":         {config.notify},
 	}
 
 	valuesReader := *strings.NewReader(values.Encode())

--- a/step.yml
+++ b/step.yml
@@ -70,6 +70,20 @@ inputs:
       description: |
         **This option will be used if the build failed.** If you
         leave this option empty then the default one will be used.
+  - notify: "false"
+    opts:
+      title: "Notify if the build succeeded"
+      is_required: true
+      value_options:
+        - true
+        - false
+  - notify_on_error: "true"
+    opts:
+      title: "Notify if the build failed"
+      is_required: true
+      value_options:
+        - true
+        - false
   - color: green
     opts:
       title: Message Color


### PR DESCRIPTION
**V1 PR available here**: https://github.com/bitrise-io/steps-hipchat/pull/17

This commit adds support for optionally notifying rooms when sending a message.

This is useful on failures, in particular, so the room is notified with a visual (and / or audible) indicator.

HipChat API Spec: https://www.hipchat.com/docs/apiv2/method/send_room_notification